### PR TITLE
FEAT: Support disabling default chat color

### DIFF
--- a/src/main/java/dev/awesomebfm/colorfulchat/ColorfulChat.java
+++ b/src/main/java/dev/awesomebfm/colorfulchat/ColorfulChat.java
@@ -41,7 +41,12 @@ public final class ColorfulChat extends JavaPlugin {
 
         // Load config
         saveDefaultConfig();
-        defaultColor = ChatColor.valueOf(getConfig().getString("default-color"));
+        try {
+            defaultColor = ChatColor.valueOf(getConfig().getString("default-color"));
+        } catch (IllegalArgumentException e) {
+            defaultColor = null;
+        }
+
 
         // Setup menu manager
         new InventoryAPI(instance).init();


### PR DESCRIPTION
Fixes #8

Just checks for Enum string conversion not working and sets to null if so.

Untested, TODO later.